### PR TITLE
Add constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 * [x] Fix undefined variable when returning `=> global`
 ---
 ### Current task
+* [ ] Mapping of generic types while checking candidates
 ---
 * [ ] Logic for printing decimals inside ppl
 * [ ] Fix `<:Self> > <:Self>`

--- a/src/ast/declarations/function.rs
+++ b/src/ast/declarations/function.rs
@@ -11,6 +11,8 @@ use crate::{
     },
 };
 
+use super::GenericParameter;
+
 /// Parameter of function
 #[derive(Debug, PartialEq, Eq, AST, Clone)]
 pub struct Parameter {
@@ -111,7 +113,7 @@ impl Parse for FunctionNamePart {
 #[derive(Debug, PartialEq, Eq, AST, Clone)]
 pub struct FunctionDeclaration {
     /// Generic parameters of a function
-    pub generic_parameters: Vec<StringWithOffset>,
+    pub generic_parameters: Vec<GenericParameter>,
     /// Name parts of function
     pub name_parts: Vec<FunctionNamePart>,
     /// Return type of function
@@ -147,7 +149,7 @@ impl Parse for FunctionDeclaration {
             .is_ok_and(|t| t.start() == fn_token.end())
         {
             context.lexer.consume(Token::Less).unwrap();
-            generic_parameters = context.parse_comma_separated(|ctx| ctx.lexer.consume(Token::Id));
+            generic_parameters = context.parse_comma_separated(GenericParameter::parse);
             context.lexer.consume_greater()?;
         }
 

--- a/src/ast/declarations/function.rs
+++ b/src/ast/declarations/function.rs
@@ -203,8 +203,8 @@ impl Parse for FunctionDeclaration {
 mod tests {
     use crate::{
         ast::{
-            FunctionDeclaration, FunctionNamePart, Parameter, Statement, TypeReference,
-            VariableReference,
+            FunctionDeclaration, FunctionNamePart, GenericParameter, Parameter, Statement,
+            TypeReference, VariableReference,
         },
         syntax::StringWithOffset,
     };
@@ -290,7 +290,10 @@ mod tests {
         assert_eq!(
             func,
             FunctionDeclaration {
-                generic_parameters: vec![StringWithOffset::from("T").at(3).into(),],
+                generic_parameters: vec![GenericParameter {
+                    name: StringWithOffset::from("T").at(3).into(),
+                    constraint: None
+                }],
                 name_parts: vec![FunctionNamePart::Parameter {
                     less: 6,
                     parameter: Parameter {
@@ -310,6 +313,45 @@ mod tests {
                 body: vec![Statement::Expression(
                     VariableReference {
                         name: StringWithOffset::from("x").at(21).into(),
+                    }
+                    .into()
+                ),],
+                implicit_return: true
+            }
+        );
+
+        let func = "fn<T: A> <x: T> -> T => x"
+            .parse::<FunctionDeclaration>()
+            .unwrap();
+        assert_eq!(
+            func,
+            FunctionDeclaration {
+                generic_parameters: vec![GenericParameter {
+                    name: StringWithOffset::from("T").at(3).into(),
+                    constraint: Some(TypeReference {
+                        name: StringWithOffset::from("A").at(6).into(),
+                        generic_parameters: vec![],
+                    })
+                }],
+                name_parts: vec![FunctionNamePart::Parameter {
+                    less: 9,
+                    parameter: Parameter {
+                        name: StringWithOffset::from("x").at(10).into(),
+                        ty: TypeReference {
+                            name: StringWithOffset::from("T").at(13).into(),
+                            generic_parameters: Vec::new(),
+                        },
+                    },
+                    greater: 14,
+                },],
+                return_type: Some(TypeReference {
+                    name: StringWithOffset::from("T").at(19).into(),
+                    generic_parameters: Vec::new(),
+                }),
+                annotations: vec![],
+                body: vec![Statement::Expression(
+                    VariableReference {
+                        name: StringWithOffset::from("x").at(24).into(),
                     }
                     .into()
                 ),],

--- a/src/ast/declarations/types.rs
+++ b/src/ast/declarations/types.rs
@@ -149,11 +149,39 @@ mod tests {
             TypeDeclaration {
                 annotations: vec![],
                 name: StringWithOffset::from("Point").at(5),
-                generic_parameters: vec![StringWithOffset::from("U").at(11),],
+                generic_parameters: vec![GenericParameter {
+                    name: StringWithOffset::from("U").at(11),
+                    constraint: None,
+                }],
                 members: vec![Member {
                     name: StringWithOffset::from("x").at(16),
                     ty: TypeReference {
                         name: StringWithOffset::from("U").at(18),
+                        generic_parameters: Vec::new(),
+                    },
+                },],
+            }
+        );
+
+        let type_decl = "type Point<U: A>:\n\tx:U"
+            .parse::<TypeDeclaration>()
+            .unwrap();
+        assert_eq!(
+            type_decl,
+            TypeDeclaration {
+                annotations: vec![],
+                name: StringWithOffset::from("Point").at(5),
+                generic_parameters: vec![GenericParameter {
+                    name: StringWithOffset::from("U").at(11),
+                    constraint: Some(TypeReference {
+                        name: StringWithOffset::from("A").at(14),
+                        generic_parameters: Vec::new()
+                    })
+                }],
+                members: vec![Member {
+                    name: StringWithOffset::from("x").at(19),
+                    ty: TypeReference {
+                        name: StringWithOffset::from("U").at(21),
                         generic_parameters: Vec::new(),
                     },
                 },],

--- a/src/hir/declarations/function.rs
+++ b/src/hir/declarations/function.rs
@@ -469,6 +469,7 @@ mod tests {
 
         let ty = GenericType {
             name: StringWithOffset::from("T").at(3),
+            constraint: None,
         };
         let param = Parameter {
             name: StringWithOffset::from("x").at(7),

--- a/src/hir/declarations/types.rs
+++ b/src/hir/declarations/types.rs
@@ -281,6 +281,7 @@ mod tests {
                 name: StringWithOffset::from("Point").at(5),
                 generic_parameters: vec![GenericType {
                     name: StringWithOffset::from("U").at(11),
+                    constraint: None
                 }
                 .into()],
                 builtin: None,
@@ -288,6 +289,7 @@ mod tests {
                     name: StringWithOffset::from("x").at(16),
                     ty: GenericType {
                         name: StringWithOffset::from("U").at(11),
+                        constraint: None,
                     }
                     .into(),
                 }),],

--- a/src/hir/types.rs
+++ b/src/hir/types.rs
@@ -8,6 +8,7 @@ use crate::{mutability::Mutable, named::Named, syntax::StringWithOffset, AddSour
 
 use super::{
     Generic, GenericName, Member, Specialize, Specialized, TraitDeclaration, TypeDeclaration,
+    TypeReference,
 };
 use derive_more::{Display, From, TryInto};
 use enum_dispatch::enum_dispatch;
@@ -127,7 +128,7 @@ pub struct GenericType {
     /// Name of the generic type
     pub name: StringWithOffset,
     /// Constraint for this type
-    pub constraint: Option<Type>,
+    pub constraint: Option<TypeReference>,
 }
 
 impl Named for GenericType {
@@ -424,10 +425,12 @@ mod tests {
 
         let t: Type = GenericType {
             name: StringWithOffset::from("T").at(7),
+            constraint: None,
         }
         .into();
         let u: Type = GenericType {
             name: StringWithOffset::from("U").at(10),
+            constraint: None,
         }
         .into();
 
@@ -459,15 +462,25 @@ mod tests {
         let b = type_decl("type B<T>");
         let c = type_decl("type C");
 
-        let x: Type = GenericType { name: "X".into() }.into();
-        let y: Type = GenericType { name: "Y".into() }.into();
+        let x: Type = GenericType {
+            name: "X".into(),
+            constraint: None,
+        }
+        .into();
+        let y: Type = GenericType {
+            name: "Y".into(),
+            constraint: None,
+        }
+        .into();
 
         let t: Type = GenericType {
             name: StringWithOffset::from("T").at(7),
+            constraint: None,
         }
         .into();
         let u: Type = GenericType {
             name: StringWithOffset::from("U").at(10),
+            constraint: None,
         }
         .into();
 

--- a/src/hir/types.rs
+++ b/src/hir/types.rs
@@ -126,6 +126,8 @@ impl Display for SelfType {
 pub struct GenericType {
     /// Name of the generic type
     pub name: StringWithOffset,
+    /// Constraint for this type
+    pub constraint: Option<Type>,
 }
 
 impl Named for GenericType {
@@ -177,7 +179,7 @@ pub enum Type {
     /// Self type and trait it represents
     SelfType(SelfType),
     /// Type for generic parameters
-    Generic(GenericType),
+    Generic(Box<GenericType>),
     /// Specialized type
     Specialized(Box<SpecializedType>),
     /// Function type
@@ -187,6 +189,12 @@ pub enum Type {
 impl From<SpecializedType> for Type {
     fn from(specialized: SpecializedType) -> Self {
         Self::Specialized(Box::new(specialized))
+    }
+}
+
+impl From<GenericType> for Type {
+    fn from(generic: GenericType) -> Self {
+        Box::new(generic).into()
     }
 }
 

--- a/src/ir/hir_to_ir.rs
+++ b/src/ir/hir_to_ir.rs
@@ -329,11 +329,12 @@ impl<'llvm> EmitBody<'llvm> for FunctionDefinition {
             let mut f_context = FunctionContext::new(context, f);
             for (i, p) in self
                 .parameters()
-                .filter(|p| !p.name().is_empty() && !p.ty().is_none())
+                .filter(|p| !p.name().is_empty() && !p.ty().specialized().is_none())
                 .enumerate()
             {
                 let alloca = f_context.builder.build_alloca(
                     p.ty()
+                        .specialized()
                         .lower_to_ir(&f_context)
                         .try_into_basic_type()
                         .unwrap(),
@@ -464,7 +465,7 @@ impl<'llvm, 'm> HIRLoweringWithinFunctionContext<'llvm, 'm> for VariableReferenc
 
     /// Lower [`VariableReference`] to LLVM IR
     fn lower_to_ir(&self, context: &mut FunctionContext<'llvm, 'm>) -> Self::IR {
-        if self.variable.ty().is_none() {
+        if self.variable.ty().specialized().is_none() {
             return None;
         }
 

--- a/src/semantics/ast_to_hir.rs
+++ b/src/semantics/ast_to_hir.rs
@@ -165,8 +165,16 @@ impl ConversionRequest {
                 .implements(tr.clone().at(self.to.source_location.clone()))
                 .within(context)
                 .map(|_| true)?,
-            // TODO: check for constraints
-            (_, Type::Generic(_)) => true,
+            (_, Type::Generic(to)) => {
+                if let Some(constraint) = to.constraint {
+                    self.from
+                        .convert_to(constraint.at(self.to.source_location.clone()))
+                        .within(context)
+                        .map(|_| true)?
+                } else {
+                    true
+                }
+            }
 
             // FIXME: rework this whole shit
             (Type::Specialized(a), Type::Specialized(b)) => a.generic == b.generic,

--- a/src/semantics/ast_to_hir.rs
+++ b/src/semantics/ast_to_hir.rs
@@ -1130,6 +1130,7 @@ mod tests {
     use crate::test_compilation_result;
 
     test_compilation_result!(candidate_not_viable);
+    test_compilation_result!(constraints);
     test_compilation_result!(generics);
     test_compilation_result!(missing_fields);
     test_compilation_result!(multiple_errors);

--- a/src/semantics/ast_to_hir.rs
+++ b/src/semantics/ast_to_hir.rs
@@ -180,6 +180,14 @@ impl ConversionRequest {
                     true
                 }
             }
+            (Type::Generic(from), _) if from.constraint.is_some() => from
+                .constraint
+                .unwrap()
+                .referenced_type
+                .at(self.from.source_location.clone())
+                .convert_to(self.to.clone())
+                .within(context)
+                .map(|_| true)?,
 
             // FIXME: rework this whole shit
             (Type::Specialized(a), Type::Specialized(b)) => a.generic == b.generic,

--- a/src/semantics/declare.rs
+++ b/src/semantics/declare.rs
@@ -39,6 +39,7 @@ impl Declare for ast::FunctionDeclaration {
             .map(|p| {
                 GenericType {
                     name: p.name.clone(),
+                    constraint: None,
                 }
                 .into()
             })
@@ -251,6 +252,7 @@ impl Declare for ast::TypeDeclaration {
             .map(|p| {
                 GenericType {
                     name: p.name.clone(),
+                    constraint: None,
                 }
                 .into()
             })

--- a/src/semantics/declare.rs
+++ b/src/semantics/declare.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use crate::{
     ast,
-    hir::{self, FunctionDefinition, GenericType, Type, Typed},
+    hir::{self, FunctionDefinition, Type, Typed},
     syntax::Ranged,
 };
 
@@ -35,15 +35,7 @@ impl Declare for ast::FunctionDeclaration {
         // TODO: check for collision
         let generic_parameters: Vec<Type> = self
             .generic_parameters
-            .iter()
-            .map(|p| {
-                GenericType {
-                    name: p.name.clone(),
-                    constraint: None,
-                }
-                .into()
-            })
-            .collect();
+            .lower_to_hir_within_context(context)?;
 
         let mut generic_context = GenericContext {
             parent: context,
@@ -248,15 +240,7 @@ impl Declare for ast::TypeDeclaration {
         // TODO: check for collisions, etc
         let generic_parameters: Vec<Type> = self
             .generic_parameters
-            .iter()
-            .map(|p| {
-                GenericType {
-                    name: p.name.clone(),
-                    constraint: None,
-                }
-                .into()
-            })
-            .collect();
+            .lower_to_hir_within_context(context)?;
 
         // TODO: recursive types
         let ty = Arc::new(hir::TypeDeclaration {

--- a/src/semantics/declare.rs
+++ b/src/semantics/declare.rs
@@ -244,8 +244,12 @@ impl Declare for ast::TypeDeclaration {
         let generic_parameters: Vec<Type> = self
             .generic_parameters
             .iter()
-            .cloned()
-            .map(|name| GenericType { name }.into())
+            .map(|p| {
+                GenericType {
+                    name: p.name.clone(),
+                }
+                .into()
+            })
             .collect();
 
         // TODO: recursive types

--- a/src/semantics/declare.rs
+++ b/src/semantics/declare.rs
@@ -36,8 +36,12 @@ impl Declare for ast::FunctionDeclaration {
         let generic_parameters: Vec<Type> = self
             .generic_parameters
             .iter()
-            .cloned()
-            .map(|name| GenericType { name }.into())
+            .map(|p| {
+                GenericType {
+                    name: p.name.clone(),
+                }
+                .into()
+            })
             .collect();
 
         let mut generic_context = GenericContext {

--- a/src/semantics/find_declaration.rs
+++ b/src/semantics/find_declaration.rs
@@ -126,9 +126,19 @@ pub trait FindDeclaration: FindDeclarationHere {
             args_cache
                 .iter()
                 .filter_map(|a| a.as_ref())
-                .filter_map(|a| match a.ty() {
+                .filter_map(|a| match a.ty().specialized() {
                     Type::Trait(tr) => Some(vec![tr].into_iter()),
                     Type::Class(c) => Some(self.traits_for(c).into_iter()),
+                    Type::Generic(g) => g
+                        .constraint
+                        .map(|c| {
+                            if let Type::Trait(tr) = c.referenced_type {
+                                Some(vec![tr].into_iter())
+                            } else {
+                                None
+                            }
+                        })
+                        .flatten(),
                     _ => None,
                 })
                 .flatten()

--- a/src/semantics/tests/constraints/constraints.ppl
+++ b/src/semantics/tests/constraints/constraints.ppl
@@ -4,6 +4,16 @@ trait Foo:
 fn<T: Foo> bar <x: T> => foo x
 
 fn foo <:None> => none
+fn foo <:Bool> => println "foo"
 
 bar none
 bar 1
+
+fn<T: Foo> baz <a: T> <b: T>:
+	foo a
+	foo b
+
+baz none none
+baz none true
+baz true none
+baz true true

--- a/src/semantics/tests/constraints/constraints.ppl
+++ b/src/semantics/tests/constraints/constraints.ppl
@@ -1,0 +1,9 @@
+trait Foo:
+	fn foo <:Self>
+
+fn<T: Foo> bar <x: T> => foo x
+
+fn foo <:None> => none
+
+bar none
+bar 1

--- a/src/semantics/tests/constraints/stderr.log
+++ b/src/semantics/tests/constraints/stderr.log
@@ -1,0 +1,39 @@
+Error: semantics::no_function
+
+  × no function `bar <:Integer>`
+    ╭─[constraints.ppl:10:5]
+  9 │ bar none
+ 10 │ bar 1
+    ·     ┬
+    ·     ╰── <:Integer>
+ 11 │ 
+    ╰────
+
+Advice:   ☞ candidate is not viable: expected `None` type, got `Integer`
+
+Error:   × None
+   ╭─[constraints.ppl:4:17]
+ 3 │ 
+ 4 │ fn<T: Foo> bar <x: T> => foo x
+   ·                 ┬
+   ·                 ╰── this has `None` type
+ 5 │ 
+   ╰────
+Error:   × Integer
+    ╭─[constraints.ppl:10:5]
+  9 │ bar none
+ 10 │ bar 1
+    ·     ┬
+    ·     ╰── this has `Integer` type
+ 11 │ 
+    ╰────
+Advice:   ☞ candidate is not viable: `Integer` doesn't satisfy trait `Foo`
+  │ requirements
+   ╭─[constraints.ppl:2:5]
+ 1 │ trait Foo:
+ 2 │     fn foo <:Self>
+   ·        ──┬──
+   ·          ╰── This required function isn't implemented
+ 3 │ 
+   ╰────
+


### PR DESCRIPTION
Note that `fn<T: Foo> baz <a: T> <b: T>` is incorrectly accepting different types (`baz none true`)